### PR TITLE
fix: loop through calendarEvents' real keys instead of indexes

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -208,7 +208,7 @@ module.exports = NodeHelper.create({
   mergeEvents: function(eventPool, calendarId) {
     this.calendarEvents[calendarId] = eventPool
     var events = []
-    for (i in Object.keys(this.calendarEvents)) {
+    for (i of Object.keys(this.calendarEvents)) {
       if (this.calendarEvents.hasOwnProperty(i)) {
         var cal = this.calendarEvents[i]
         events = events.concat(cal)


### PR DESCRIPTION
Hi there!

I noticed a bug in `mergeEvents()`, so I decided to open a PR to fix it :slightly_smiling_face: 

When one of your calendar is invalid for some reasons (in my case, my URL was returning an HTML file instead of an ICS file), the parsing from the `ical.js` lib will throw, resulting in the calendar not being added to the list of valid calendars.

Consider your errored calendar had `3` as its uid, `Object.keys(this.calendarEvents)` will contain `['0', '1', '2', '4']` after having removed it. If you use `in` instead of `of` to loop through this array, `i` will have the value `3` when it should be `4`.

Thanks for your work on this module!