### PR TITLE
Update MMM-CalendarExt2.css

### DIFF
--- a/MMM-CalendarExt2.css
+++ b/MMM-CalendarExt2.css
@@ -284,7 +284,7 @@
 }
 
 .CX2 .eventTime .end::before {
-  content:"\00a0-\00a0";
+  content:"-\00a0";
 }
 
 .CX2 .event.passed::before { /* If you don't want to passed pattern, overwrite this */


### PR DESCRIPTION
removed \00a0 this creates and extra space

before
![image](https://user-images.githubusercontent.com/21694965/97406956-45fc8600-18fa-11eb-9267-0615e1984861.png)
![image](https://user-images.githubusercontent.com/21694965/97407301-c9b67280-18fa-11eb-8f36-adec87746366.png)


after
![image](https://user-images.githubusercontent.com/21694965/97407119-83f9aa00-18fa-11eb-842b-15469bf63f99.png)
![image](https://user-images.githubusercontent.com/21694965/97407275-bf947400-18fa-11eb-86f4-0df09a77c343.png)

