### PR TITLE
Add base-64 to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,18 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "base-64": "^1.0.0",
         "ical-expander": "^3.1.0",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.34",
         "node-fetch": "^3.2.0",
         "valid-url": "^1.0.9"
       }
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.0",
@@ -142,6 +148,11 @@
     }
   },
   "dependencies": {
+    "base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
+    },
     "data-uri-to-buffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/MMM-CalendarExt2/MMM-CalendarExt2#readme",
   "dependencies": {
+    "base-64": "^1.0.0",
     "ical-expander": "^3.1.0",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.34",


### PR DESCRIPTION
It currently works because `base-64` is in the dependency tree of MagicMirror². We should not rely on that.