### PR TITLE
Remove fixed point release

### DIFF
--- a/.github/workflows/superlinter.yaml
+++ b/.github/workflows/superlinter.yaml
@@ -24,7 +24,7 @@ jobs:
 
       # Runs the Super-Linter action
       - name: Run Super-Linter
-        uses: github/super-linter/slim@v4.8.5
+        uses: github/super-linter/slim@v4
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I don't think using a fixed point release is necessary. This also corresponds to Super-Linter's example configuration: https://github.com/github/super-linter#example-connecting-github-action-workflow