### PR TITLE
Prevent double render

### DIFF
--- a/MMM-CalendarExt2.js
+++ b/MMM-CalendarExt2.js
@@ -271,18 +271,22 @@ Module.register("MMM-CalendarExt2", {
   },
 
   suspend() {
-    this.showing = false;
-    if (this.currentScene) {
-      this.currentScene.clearViews();
+    if (this.showing) {
+      this.showing = false;
+      if (this.currentScene) {
+        this.currentScene.clearViews();
+      }
     }
   },
 
   resume() {
-    this.showing = true;
-    if (this.currentScene) {
-      this.work(this.currentSceneUid);
-    } else {
-      this.work();
+    if (!this.showing) {
+      this.showing = true;
+      if (this.currentScene) {
+        this.work(this.currentSceneUid);
+      } else {
+        this.work();
+      }
     }
   },
 


### PR DESCRIPTION
Updated resume and suspend functions.  Adds simple error checking when called.  only execute resume if actually suspended, and only execute suspend if not in run.  Addresses double render issue (#198), especially when working in conjunction with MMM-Pages, where resume is called on the module but the module is not actually suspended.