### PR TITLE
Reduce super-linter issues

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -4,6 +4,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+permissions: read-all
 jobs:
   run-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -19,7 +19,7 @@ on:
     branches: [main]
   schedule:
     - cron: "43 19 * * 6"
-
+permissions: read-all
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/superlinter.yaml
+++ b/.github/workflows/superlinter.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
   pull_request:
-
+permissions: read-all
 jobs:
   # Set the job key. The key is displayed as the job name
   # when a job name is not provided

--- a/.github/workflows/superlinter.yaml
+++ b/.github/workflows/superlinter.yaml
@@ -29,7 +29,7 @@ jobs:
 
       # Runs the Super-Linter action
       - name: Run Super-Linter
-        uses: github/super-linter/slim@v4
+        uses: super-linter/super-linter/slim@v6
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/superlinter.yaml
+++ b/.github/workflows/superlinter.yaml
@@ -16,12 +16,19 @@ jobs:
     # Set the type of machine to run on
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
       statuses: write
 
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
 
       - name: install modules
         run: |

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
   "scripts": {
     "lint": "npm run eslint && npm run stylelint",
     "lint:fix": "npm run eslint:fix && npm run stylelint:fix",
-    "eslint": "bash -c 'eslint -c .eslintrc.json ${@:-.}' -- ",
-    "eslint:fix": "bash -c 'eslint -c .eslintrc.json --fix ${@:-.}' -- ",
-    "stylelint": "stylelint --config .stylelintrc.json **/*.css",
-    "stylelint:fix": "stylelint --config .stylelintrc.json --fix **/*.css",
-    "prettier": "bash -c 'prettier -c ${@:-.}' -- ",
-    "prettier:fix": "bash -c 'prettier -w ${@:-.}' -- ",
+    "eslint": "eslint .",
+    "eslint:fix": "eslint . --fix",
+    "stylelint": "stylelint **/*.css",
+    "stylelint:fix": "stylelint **/*.css --fix",
+    "prettier": "prettier . --check",
+    "prettier:fix": "prettier . --write",
     "test": "npm run lint && npm run prettier"
   }
 }


### PR DESCRIPTION
[Before](https://github.com/MMM-CalendarExt2/MMM-CalendarExt2/actions/runs/8308335330/job/22738475099#step:5:3339):

```
2024-03-16 14:15:21 [ERROR]   ERRORS FOUND in CSS:[1]
2024-03-16 14:15:23 [ERROR]   ERRORS FOUND in JAVASCRIPT_ES:[19]
2024-03-16 14:15:23 [ERROR]   ERRORS FOUND in JAVASCRIPT_PRETTIER:[1]
2024-03-16 14:15:24 [ERROR]   ERRORS FOUND in JSON:[6]
```

[After](https://github.com/KristjanESPERANTO/MMM-CalendarExt2/actions/runs/8314821445/job/22752441901#step:5:440):

```
2024-03-17 10:39:53 [ERROR]   Errors found in CSS
```

The last one stands because super-linter still uses stylelint v15 and we've already switched to v16.